### PR TITLE
Fix/ Bug : Cannot use 'in' operator to search for 'url' in null 

### DIFF
--- a/app/Jobs/SendWhatsAppPopUpMessageJob.php
+++ b/app/Jobs/SendWhatsAppPopUpMessageJob.php
@@ -94,8 +94,11 @@ class SendWhatsAppPopUpMessageJob implements ShouldQueue
         $payload = [
             'phone'   => $this->requestData['celular'],
             'message' => $message,
-            'image'   => $imageData,
         ];
+
+        if ($imageData) {
+            $payload['image'] = $imageData;
+        }
 
         Log::info('Enviando petición a WhatsApp:', [
             'url' => $url,


### PR DESCRIPTION
WhatsApp popup inicio envio campaña, error al enviar imagen en null.
Se agrego validacion para no enviar null.